### PR TITLE
Add meetings page and monitoring setup

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -185,7 +185,7 @@ documented on the maps and resources pages.
 ## Newsletter signup
 
 `/emailsignup` is wired up to **Listmonk** at
-`https://lists.louisianamesh.org/subscription/form` (POST, `no-cors`). Two
+`https://lists.gulfcoastmesh.org/subscription/form` (POST, `no-cors`). Two
 list IDs live at the top of `app/emailsignup/page.tsx`:
 
 - `ALERTS_LIST_ID` — required, posted on every submit.

--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1,0 +1,231 @@
+# Public API
+
+Read-only HTTP API for published Gulf Coast Mesh meeting records. No authentication is required.
+
+**Production base URL:** `https://meeting.gulfcoastmesh.org`
+
+Only meetings that have been **ended**, **transcribed**, **summarized**, and **published** (with a YouTube URL set in the admin export UI) appear in these endpoints. Unpublished or incomplete meetings are omitted entirely.
+
+## Base URL
+
+| Environment | Base URL |
+|-------------|----------|
+| Local dev (API only) | `http://127.0.0.1:3001` |
+| Local dev (via Vite proxy) | `http://127.0.0.1:5180` |
+| Production | `https://meeting.gulfcoastmesh.org` |
+
+In production, run the export server with static client assets:
+
+```sh
+npm run app:web:prod
+```
+
+Default port is `3001` (`EXPORT_APP_PORT`). Host defaults to `0.0.0.0` (`EXPORT_APP_HOST`).
+
+All paths below are relative to the base URL.
+
+## CORS
+
+Public routes send:
+
+```
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, OPTIONS
+Access-Control-Allow-Headers: Content-Type
+```
+
+`OPTIONS` preflight requests return `204 No Content`. Cross-origin browser clients may call these endpoints without credentials.
+
+## Meeting IDs
+
+Meeting IDs are folder names under `recordings/`, for example `2026-05-18_18-31`.
+
+Allowed characters: letters, numbers, dots, underscores, and hyphens.
+
+## Endpoints
+
+### List published meetings
+
+```
+GET /api/public/meetings
+```
+
+Returns a summary for each published meeting, newest first.
+
+**Response `200`**
+
+```json
+{
+  "meetings": [
+    {
+      "id": "2026-05-18_18-31",
+      "dateLabel": "May 18, 2026",
+      "startedAt": "2026-05-18T23:31:00.000Z",
+      "endedAt": "2026-05-19T01:15:00.000Z",
+      "youtubeUrl": "https://youtu.be/n_fmH2eKxq4",
+      "publishedAt": "2026-05-24T21:59:30.032Z",
+      "agendas": [
+        {
+          "originalName": "2026-05-18-agenda.pdf",
+          "contentType": "application/pdf",
+          "uploadedAt": "2026-05-18T23:25:00.000Z",
+          "size": 84213,
+          "downloadUrl": "/api/public/meetings/2026-05-18_18-31/agenda/2026-05-18-agenda.pdf"
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Meeting identifier |
+| `dateLabel` | string | Human-readable date (US long format, America/Chicago) |
+| `startedAt` | string | ISO 8601 UTC start time |
+| `endedAt` | string | ISO 8601 UTC end time |
+| `youtubeUrl` | string | Published YouTube link |
+| `publishedAt` | string | ISO 8601 UTC publish time |
+| `agendas` | array | Agenda files attached to the meeting (may be empty) |
+
+Agenda `downloadUrl` values are **relative paths**. Prepend your API base URL to fetch the file, for example:
+
+`https://meeting.gulfcoastmesh.org/api/public/meetings/2026-05-18_18-31/agenda/2026-05-18-agenda.pdf`
+
+---
+
+### Get published meeting detail
+
+```
+GET /api/public/meetings/:meetingId
+```
+
+Returns transcript and recap text in addition to the summary fields above.
+
+**Response `200`**
+
+```json
+{
+  "id": "2026-05-18_18-31",
+  "dateLabel": "May 18, 2026",
+  "startedAt": "2026-05-18T23:31:00.000Z",
+  "endedAt": "2026-05-19T01:15:00.000Z",
+  "youtubeUrl": "https://youtu.be/n_fmH2eKxq4",
+  "publishedAt": "2026-05-24T21:59:30.032Z",
+  "agendas": [],
+  "transcript": "Full meeting transcript text…",
+  "recap": "# Meeting recap\n\n- Action item one\n- Action item two"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transcript` | string | Plain-text transcript (`transcript/transcript.txt`) |
+| `recap` | string | Markdown recap (`summary/recap.md`) |
+
+**Response `404`**
+
+```json
+{
+  "error": "Published meeting not found."
+}
+```
+
+Returned when the meeting does not exist, is not published, or is missing transcript/recap content.
+
+---
+
+### Download agenda file
+
+```
+GET /api/public/meetings/:meetingId/agenda/:fileName
+```
+
+Downloads an agenda PDF (or other uploaded agenda file) for a published meeting.
+
+- `:fileName` must match an agenda's `originalName` from the list or detail response.
+- Use URL encoding for special characters in the filename (the API returns encoded paths in `downloadUrl`).
+
+**Response `200`**
+
+Binary file download with the original filename.
+
+**Response `404` / `500`**
+
+```json
+{
+  "error": "Published meeting not found."
+}
+```
+
+or
+
+```json
+{
+  "error": "Agenda file not found."
+}
+```
+
+## Error format
+
+Most errors return JSON:
+
+```json
+{
+  "error": "Human-readable message"
+}
+```
+
+| Status | When |
+|--------|------|
+| `404` | Unknown or unpublished meeting, missing agenda |
+| `500` | Unexpected server error |
+
+## Examples
+
+List all published meetings:
+
+```sh
+curl -s https://meeting.gulfcoastmesh.org/api/public/meetings | jq .
+```
+
+Fetch one meeting (transcript + recap):
+
+```sh
+curl -s https://meeting.gulfcoastmesh.org/api/public/meetings/2026-05-18_18-31 | jq .
+```
+
+Download an agenda:
+
+```sh
+curl -LO "https://meeting.gulfcoastmesh.org/api/public/meetings/2026-05-18_18-31/agenda/2026-05-18-agenda.pdf"
+```
+
+Local development (API on port 3001):
+
+```sh
+curl -s http://127.0.0.1:3001/api/public/meetings
+curl -s http://127.0.0.1:3001/api/public/meetings/2026-05-18_18-31
+```
+
+## What is not public
+
+These require admin login (`EXPORT_APP_PASSWORD`):
+
+- Creating or editing transcripts and recaps
+- Transcribing, summarizing, or rendering video
+- Publishing or unpublishing meetings
+- Downloading admin-only MP4 exports under `/api/meetings/...`
+
+Auth endpoints (`/api/auth/login`, `/api/auth/logout`, `/api/auth/status`) are separate from the public API and do not gate public reads.
+
+## Publishing workflow (admin)
+
+For a meeting to appear in the public API:
+
+1. Recording ends (meeting has an `endedAt` timestamp).
+2. Transcript is generated or saved.
+3. Recap is generated or saved.
+4. Admin sets a YouTube URL and clicks **Publish** in the export web UI.
+
+After publish, `publish.json` is written under the meeting folder and the meeting becomes visible on the public endpoints.

--- a/app/emailsignup/page.tsx
+++ b/app/emailsignup/page.tsx
@@ -27,7 +27,7 @@ export default function EmailSignupPage() {
     if (formData.get("weekly")) params.append("l", NEWS_LIST_ID);
 
     try {
-      await fetch("https://lists.louisianamesh.org/subscription/form", {
+      await fetch("https://lists.gulfcoastmesh.org/subscription/form", {
         method: "POST",
         mode: "no-cors",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },

--- a/app/meetings/page.tsx
+++ b/app/meetings/page.tsx
@@ -1,0 +1,222 @@
+import Link from "next/link";
+import {
+  ArrowUpRight,
+  CalendarDays,
+  ChevronDown,
+  FileText,
+  MessageSquare,
+  Youtube,
+} from "lucide-react";
+
+import { MeetingsCalendar } from "@/components/meetings-calendar";
+import { NextMeetingCard } from "@/components/next-meeting-card";
+import {
+  absoluteAgendaUrl,
+  formatTimeEt,
+  getPublishedMeetingsWithRecap,
+  meetingDateKeyEt,
+  type PublicMeetingWithRecap,
+} from "@/lib/meetings";
+
+export const metadata = {
+  title: "Meetings",
+  description:
+    "Weekly Gulf Coast Mesh voice meeting — every Monday 7:30 - 10:00 PM ET — plus the archive of past published meetings with YouTube recaps and agendas.",
+};
+
+export const revalidate = 300;
+
+export default async function MeetingsPage() {
+  const meetings = await getPublishedMeetingsWithRecap();
+
+  // ET-date keyed lookup powers the calendar's "is this Monday published?"
+  // logic. We bucket by the meeting's starting day in America/New_York so a
+  // meeting that crosses midnight UTC still maps to the correct Monday cell.
+  const publishedByDateKey: Record<
+    string,
+    { id: string; youtubeUrl: string; dateLabel: string }
+  > = {};
+  for (const m of meetings) {
+    const key = meetingDateKeyEt(m.startedAt);
+    if (key && m.youtubeUrl) {
+      publishedByDateKey[key] = {
+        id: m.id,
+        youtubeUrl: m.youtubeUrl,
+        dateLabel: m.dateLabel,
+      };
+    }
+  }
+
+  return (
+    <div className="container pb-24">
+      <header className="mx-auto max-w-3xl text-center">
+        <span className="eyebrow mx-auto">
+          <CalendarDays className="h-3.5 w-3.5" aria-hidden />
+          Meetings
+        </span>
+        <h1 className="mt-5 font-display text-display-xl font-semibold tracking-tight text-balance text-ink-900 dark:text-white">
+          Every Monday on the mesh.
+        </h1>
+        <p className="mt-5 text-pretty text-lg text-ink-600 dark:text-ink-300">
+          The Gulf Coast Mesh voice meeting runs every Monday from{" "}
+          <span className="font-semibold text-ink-800 dark:text-ink-100">7:30 - 10:00 PM ET</span>{" "}
+          on Discord. New operators welcome — drop in, listen, or hop on mic.
+        </p>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+          <a
+            href="https://discord.gulfcoastmesh.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-primary"
+          >
+            <MessageSquare className="h-4 w-4" aria-hidden />
+            Open Discord
+          </a>
+          <Link href="#archive" className="btn-ghost">
+            See past meetings
+          </Link>
+        </div>
+      </header>
+
+      <NextMeetingCard />
+
+      <MeetingsCalendar publishedByDateKey={publishedByDateKey} />
+
+      <section id="archive" className="mt-20">
+        <div className="mb-6 flex items-end justify-between gap-4">
+          <div>
+            <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-gulf-700 dark:text-gulf-300">
+              Archive
+            </p>
+            <h2 className="mt-1 font-display text-2xl font-semibold tracking-tight text-ink-900 sm:text-3xl dark:text-white">
+              Past meetings
+            </h2>
+          </div>
+          {meetings.length > 0 ? (
+            <p className="hidden text-sm text-ink-500 sm:block dark:text-ink-400">
+              {meetings.length} published recap{meetings.length === 1 ? "" : "s"} · newest first
+            </p>
+          ) : null}
+        </div>
+
+        {meetings.length === 0 ? (
+          <div className="surface p-8 text-center text-sm text-ink-600 dark:text-ink-300">
+            Past meetings will appear here once the next one is published. Want to be in
+            the room? Hop into{" "}
+            <a
+              href="https://discord.gulfcoastmesh.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-gulf-700 underline-offset-4 hover:underline dark:text-gulf-300"
+            >
+              Discord
+            </a>
+            .
+          </div>
+        ) : (
+          <ul className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {meetings.map((m) => (
+              <PastMeetingCard key={m.id} meeting={m} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <p className="mt-16 text-center text-sm text-ink-500 dark:text-ink-400">
+        <Link href="/" className="font-medium text-gulf-700 hover:underline dark:text-gulf-300">
+          ← Back to home
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+function PastMeetingCard({ meeting }: { meeting: PublicMeetingWithRecap }) {
+  const startedAt = formatTimeEt(meeting.startedAt);
+  const endedAt = formatTimeEt(meeting.endedAt);
+  const timeRange = startedAt && endedAt ? `${startedAt} - ${endedAt} ET` : null;
+
+  return (
+    <li className="tile group flex h-full flex-col">
+      <div className="flex items-center justify-between gap-3">
+        <span className="grid h-11 w-11 place-items-center rounded-2xl bg-gulf-500/15 text-gulf-700 dark:text-gulf-300">
+          <CalendarDays className="h-5 w-5" aria-hidden />
+        </span>
+        {meeting.youtubeUrl ? (
+          <span className="inline-flex items-center gap-1 rounded-full bg-sand-400/15 px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-sand-700 dark:text-sand-300">
+            <Youtube className="h-3 w-3" aria-hidden />
+            Recap
+          </span>
+        ) : null}
+      </div>
+      <h3 className="mt-5 font-display text-lg font-semibold text-ink-900 dark:text-white">
+        {meeting.dateLabel}
+      </h3>
+      {timeRange ? (
+        <p className="mt-1 font-mono text-[11px] uppercase tracking-[0.18em] text-ink-500 dark:text-ink-400">
+          {timeRange}
+        </p>
+      ) : null}
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {meeting.youtubeUrl ? (
+          <a
+            href={meeting.youtubeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group/link inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold text-gulf-700 transition hover:border-gulf-400/60 hover:bg-gulf-500/5 dark:border-white/10 dark:text-gulf-300"
+            style={{ borderColor: "rgb(var(--line) / 0.7)" }}
+          >
+            <Youtube className="h-3.5 w-3.5" aria-hidden />
+            Watch on YouTube
+            <ArrowUpRight
+              className="h-3 w-3 transition group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5"
+              aria-hidden
+            />
+          </a>
+        ) : null}
+      </div>
+
+      {meeting.recapHtml ? (
+        <details className="group/recap mt-4 border-t border-ink-200/60 pt-4 dark:border-white/10">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded-lg text-left font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-ink-600 transition hover:text-ink-900 dark:text-ink-300 dark:hover:text-white">
+            <span>Meeting summary</span>
+            <ChevronDown
+              className="h-3.5 w-3.5 transition-transform group-open/recap:rotate-180"
+              aria-hidden
+            />
+          </summary>
+          <div
+            className="prose-mesh prose-sm mt-3 text-sm"
+            dangerouslySetInnerHTML={{ __html: meeting.recapHtml }}
+          />
+        </details>
+      ) : null}
+
+      {meeting.agendas.length > 0 ? (
+        <div className="mt-4 border-t border-ink-200/60 pt-4 dark:border-white/10">
+          <p className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-ink-500 dark:text-ink-400">
+            Agenda
+          </p>
+          <ul className="flex flex-wrap gap-1.5">
+            {meeting.agendas.map((a) => (
+              <li key={a.originalName}>
+                <a
+                  href={absoluteAgendaUrl(a.downloadUrl)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-full border bg-white/70 px-2.5 py-1 text-xs font-medium text-ink-700 transition hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-ink-100 dark:hover:bg-white/10"
+                  style={{ borderColor: "rgb(var(--line) / 0.6)" }}
+                  title={a.originalName}
+                >
+                  <FileText className="h-3 w-3" aria-hidden />
+                  <span className="max-w-[12rem] truncate">{a.originalName}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </li>
+  );
+}

--- a/components/meetings-calendar.tsx
+++ b/components/meetings-calendar.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ArrowUpRight, ChevronLeft, ChevronRight, Youtube } from "lucide-react";
+import { useHasMounted } from "@/lib/use-has-mounted";
+
+/**
+ * Month-grid calendar for /meetings.
+ *
+ * The grid is rendered in ET because the underlying schedule is ET-anchored
+ * (every Monday 7:30 - 10:00 PM ET). That keeps "which Monday is which"
+ * unambiguous regardless of where the visitor sits. Past Mondays for which
+ * the public API returned a published recap get a YouTube link inline.
+ *
+ * SSR-safe: the outer wrapper renders a stable skeleton while hydrating. Only
+ * after mount does the inner component subscribe to the visitor's clock, so
+ * the server and the first client render emit identical markup.
+ */
+
+type CalendarMeeting = {
+  id: string;
+  youtubeUrl: string;
+  dateLabel: string;
+};
+
+type Props = {
+  publishedByDateKey: Record<string, CalendarMeeting>;
+};
+
+const MEETING_TZ = "America/New_York";
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function nowInEt(now: Date) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: MEETING_TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(now);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+  return {
+    year: parseInt(get("year"), 10),
+    month: parseInt(get("month"), 10),
+    day: parseInt(get("day"), 10),
+  };
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+function keyOf(year: number, month: number, day: number): string {
+  return `${year}-${pad2(month)}-${pad2(day)}`;
+}
+
+type Cell = {
+  key: string;
+  year: number;
+  month: number;
+  day: number;
+  inMonth: boolean;
+  /** 0 = Sunday … 6 = Saturday */
+  weekday: number;
+};
+
+function buildMonthCells(year: number, month: number): Cell[] {
+  // Anchor on UTC midnight so `getUTCDay()` is consistent regardless of where
+  // this code runs. This is purely a calendar-math helper; we treat the
+  // (year, month, day) tuple as the ET wall date with no timezone ambiguity.
+  const firstOfMonth = new Date(Date.UTC(year, month - 1, 1));
+  const firstWeekday = firstOfMonth.getUTCDay();
+  const startDay = 1 - firstWeekday;
+  const cells: Cell[] = [];
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(Date.UTC(year, month - 1, startDay + i));
+    const y = d.getUTCFullYear();
+    const m = d.getUTCMonth() + 1;
+    const day = d.getUTCDate();
+    cells.push({
+      key: keyOf(y, m, day),
+      year: y,
+      month: m,
+      day,
+      inMonth: m === month,
+      weekday: d.getUTCDay(),
+    });
+  }
+  return cells;
+}
+
+export function MeetingsCalendar({ publishedByDateKey }: Props) {
+  const mounted = useHasMounted();
+  if (!mounted) {
+    return (
+      <section
+        className="surface mt-10 p-6 sm:p-8"
+        aria-label="Meetings calendar (loading)"
+      >
+        <div className="h-[420px] animate-pulse rounded-2xl bg-ink-100/40 dark:bg-white/5" />
+      </section>
+    );
+  }
+  return <MountedCalendar publishedByDateKey={publishedByDateKey} />;
+}
+
+function MountedCalendar({ publishedByDateKey }: Props) {
+  // Initial view is the current ET month, captured once on mount. This
+  // initializer only runs after hydration (because the parent gates rendering
+  // on `useHasMounted`), so reading the visitor's clock is safe here.
+  const [view, setView] = useState<{ year: number; month: number }>(() => {
+    const et = nowInEt(new Date());
+    return { year: et.year, month: et.month };
+  });
+  const todayKey = useMemo(() => {
+    const et = nowInEt(new Date());
+    return keyOf(et.year, et.month, et.day);
+  }, []);
+
+  const cells = useMemo(() => buildMonthCells(view.year, view.month), [view]);
+
+  const goPrev = () =>
+    setView((v) => {
+      const m = v.month - 1;
+      if (m < 1) return { year: v.year - 1, month: 12 };
+      return { year: v.year, month: m };
+    });
+  const goNext = () =>
+    setView((v) => {
+      const m = v.month + 1;
+      if (m > 12) return { year: v.year + 1, month: 1 };
+      return { year: v.year, month: m };
+    });
+  const goToday = () => {
+    const et = nowInEt(new Date());
+    setView({ year: et.year, month: et.month });
+  };
+
+  return (
+    <section className="surface relative mt-10 overflow-hidden p-4 sm:p-6">
+      <header className="flex items-center justify-between gap-3 px-1 pb-4">
+        <div>
+          <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-gulf-700 dark:text-gulf-300">
+            Schedule (ET)
+          </p>
+          <h2 className="mt-1 font-display text-2xl font-semibold tracking-tight text-ink-900 dark:text-white">
+            {MONTH_NAMES[view.month - 1]} {view.year}
+          </h2>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={goPrev}
+            aria-label="Previous month"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-xl border bg-white/70 text-ink-700 transition hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-ink-100 dark:hover:bg-white/10"
+            style={{ borderColor: "rgb(var(--line) / 0.7)" }}
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+          </button>
+          <button
+            type="button"
+            onClick={goToday}
+            className="inline-flex h-9 items-center rounded-xl border bg-white/70 px-3 text-xs font-semibold text-ink-700 transition hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-ink-100 dark:hover:bg-white/10"
+            style={{ borderColor: "rgb(var(--line) / 0.7)" }}
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            onClick={goNext}
+            aria-label="Next month"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-xl border bg-white/70 text-ink-700 transition hover:bg-white dark:border-white/10 dark:bg-white/5 dark:text-ink-100 dark:hover:bg-white/10"
+            style={{ borderColor: "rgb(var(--line) / 0.7)" }}
+          >
+            <ChevronRight className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+      </header>
+
+      <div className="grid grid-cols-7 gap-1 px-1 pb-2 text-center font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-ink-500 dark:text-ink-400">
+        {DOW_LABELS.map((d) => (
+          <div key={d}>{d}</div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 gap-1 px-1 pb-1">
+        {cells.map((cell) => (
+          <CalendarCell
+            key={cell.key}
+            cell={cell}
+            todayKey={todayKey}
+            published={publishedByDateKey[cell.key]}
+          />
+        ))}
+      </div>
+
+      <p className="mt-4 px-1 text-xs text-ink-500 dark:text-ink-400">
+        Mondays are meeting nights — 7:30 - 10:00 PM ET. Past Mondays link to the YouTube recap when published.
+      </p>
+    </section>
+  );
+}
+
+function CalendarCell({
+  cell,
+  todayKey,
+  published,
+}: {
+  cell: Cell;
+  todayKey: string;
+  published?: CalendarMeeting;
+}) {
+  const isMonday = cell.weekday === 1;
+  const isToday = todayKey === cell.key;
+  const isPast = cell.key < todayKey;
+
+  const baseClass =
+    "relative flex aspect-square min-h-[58px] flex-col rounded-xl border p-1.5 text-left transition sm:min-h-[72px] sm:p-2";
+  const mutedText = cell.inMonth ? "" : "opacity-40";
+  const todayRing = isToday ? "ring-2 ring-gulf-400/60 ring-offset-1 ring-offset-transparent" : "";
+  const mondayAccent = isMonday
+    ? "border-gulf-400/40 bg-gulf-500/5 dark:border-gulf-400/30 dark:bg-gulf-500/10"
+    : "";
+  const inactiveBorder = !isMonday
+    ? "border-ink-200/60 bg-white/40 dark:border-white/10 dark:bg-white/[0.02]"
+    : "";
+
+  const inner = (
+    <>
+      <span
+        className={
+          "inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold " +
+          (isMonday
+            ? "bg-gulf-500/20 text-gulf-700 dark:text-gulf-200"
+            : "text-ink-700 dark:text-ink-200")
+        }
+      >
+        {cell.day}
+      </span>
+      {isMonday ? (
+        <div className="mt-auto flex flex-col gap-0.5">
+          <span className="hidden font-mono text-[9px] font-semibold uppercase tracking-[0.18em] text-gulf-700 sm:inline dark:text-gulf-300">
+            7:30 PM ET
+          </span>
+          {published ? (
+            <span className="inline-flex items-center gap-1 self-start rounded-full bg-sand-400/20 px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-sand-700 dark:text-sand-300">
+              <Youtube className="h-2.5 w-2.5" aria-hidden />
+              Recap
+            </span>
+          ) : isPast ? null : (
+            <span className="inline-flex items-center gap-1 self-start rounded-full bg-gulf-500/15 px-1.5 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-gulf-700 dark:text-gulf-200">
+              <span className="h-1 w-1 rounded-full bg-gulf-500" />
+              Meeting
+            </span>
+          )}
+        </div>
+      ) : null}
+    </>
+  );
+
+  if (isMonday && published) {
+    return (
+      <a
+        href={published.youtubeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`Recap — ${published.dateLabel}`}
+        className={`${baseClass} ${mondayAccent} ${todayRing} ${mutedText} group cursor-pointer hover:-translate-y-0.5 hover:border-gulf-400/70 hover:bg-gulf-500/10`}
+      >
+        {inner}
+        <ArrowUpRight
+          className="pointer-events-none absolute right-1.5 top-1.5 h-3 w-3 text-gulf-700 opacity-0 transition group-hover:opacity-100 dark:text-gulf-300"
+          aria-hidden
+        />
+      </a>
+    );
+  }
+
+  return (
+    <div className={`${baseClass} ${isMonday ? mondayAccent : inactiveBorder} ${todayRing} ${mutedText}`}>
+      {inner}
+    </div>
+  );
+}

--- a/components/next-meeting-card.tsx
+++ b/components/next-meeting-card.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUpRight, CalendarClock } from "lucide-react";
+import { useHasMounted } from "@/lib/use-has-mounted";
+
+/**
+ * "Next meeting" hero card for /meetings.
+ *
+ * Source of truth: the community meeting runs every Monday from 7:30 PM to
+ * 10:00 PM America/New_York (Eastern). This card translates the next
+ * occurrence into the visitor's local clock so a member on the Gulf Coast
+ * sees their own time, not someone else's.
+ *
+ * SSR-safe: while hydrating, the wrapper renders a static placeholder. Only
+ * after mount does it swap to the localized "in X hours" string, which keeps
+ * the server-rendered HTML stable across timezones.
+ */
+
+const MEETING_TZ = "America/New_York";
+const MEETING_HOUR = 19;
+const MEETING_MINUTE = 30;
+const MEETING_END_HOUR = 22;
+const MEETING_END_MINUTE = 0;
+
+function tzWallToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  timeZone: string,
+): Date {
+  // Convert a (year, month, day, hour, minute) tuple interpreted in `timeZone`
+  // into the corresponding UTC instant. Works around the lack of a native
+  // `Date.fromZoned` by using the "guess and correct" trick:
+  //   1. Treat the wall-time as if it were UTC ("guess").
+  //   2. Ask Intl what that guessed instant *displays as* in the target zone.
+  //   3. The delta between the wall-time and what the zone displays is the
+  //      offset we need to subtract to get the true UTC instant.
+  const guessMs = Date.UTC(year, month - 1, day, hour, minute);
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(new Date(guessMs));
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "0";
+  const zonedMs = Date.UTC(
+    parseInt(get("year"), 10),
+    parseInt(get("month"), 10) - 1,
+    parseInt(get("day"), 10),
+    parseInt(get("hour"), 10) % 24,
+    parseInt(get("minute"), 10),
+  );
+  return new Date(guessMs + (guessMs - zonedMs));
+}
+
+type EtCalendar = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  weekday: number;
+};
+
+function nowInEt(now: Date): EtCalendar {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: MEETING_TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    weekday: "short",
+    hour12: false,
+  }).formatToParts(now);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+  const weekdayMap: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  return {
+    year: parseInt(get("year"), 10),
+    month: parseInt(get("month"), 10),
+    day: parseInt(get("day"), 10),
+    hour: parseInt(get("hour"), 10) % 24,
+    minute: parseInt(get("minute"), 10),
+    weekday: weekdayMap[get("weekday")] ?? 0,
+  };
+}
+
+type NextMeeting = {
+  start: Date;
+  end: Date;
+  inProgress: boolean;
+};
+
+function computeNextMeeting(now: Date): NextMeeting {
+  const et = nowInEt(now);
+  let daysToAdd = (1 - et.weekday + 7) % 7;
+  if (daysToAdd === 0) {
+    const minutesNow = et.hour * 60 + et.minute;
+    const endMinutes = MEETING_END_HOUR * 60 + MEETING_END_MINUTE;
+    if (minutesNow >= endMinutes) {
+      // It's Monday in ET but the meeting has already ended. Skip ahead a week.
+      daysToAdd = 7;
+    }
+  }
+  // Adding to `day` lets the Date constructor normalize end-of-month rollovers
+  // for us, so we don't have to special-case Jan 31 + 1 = Feb 1, etc.
+  const targetUtc = new Date(Date.UTC(et.year, et.month - 1, et.day + daysToAdd));
+  const ty = targetUtc.getUTCFullYear();
+  const tm = targetUtc.getUTCMonth() + 1;
+  const td = targetUtc.getUTCDate();
+
+  const start = tzWallToUtc(ty, tm, td, MEETING_HOUR, MEETING_MINUTE, MEETING_TZ);
+  const end = tzWallToUtc(ty, tm, td, MEETING_END_HOUR, MEETING_END_MINUTE, MEETING_TZ);
+  return {
+    start,
+    end,
+    inProgress: now >= start && now <= end,
+  };
+}
+
+function formatLocal(start: Date): string {
+  return start.toLocaleString(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+function formatCountdown(start: Date, now: Date): string {
+  const diffMs = start.getTime() - now.getTime();
+  if (diffMs <= 0) return "Happening now";
+  const minutes = Math.floor(diffMs / 60_000);
+  const days = Math.floor(minutes / (60 * 24));
+  const hours = Math.floor((minutes % (60 * 24)) / 60);
+  const mins = minutes % 60;
+  if (days > 0) return `in ${days}d ${hours}h`;
+  if (hours > 0) return `in ${hours}h ${mins}m`;
+  if (mins > 0) return `in ${mins} min`;
+  return "starting now";
+}
+
+function Shell({
+  eyebrow,
+  localized,
+  countdown,
+}: {
+  eyebrow: string;
+  localized: string;
+  countdown: string;
+}) {
+  return (
+    <section className="surface relative mt-12 overflow-hidden p-6 sm:p-8">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-gulf-400/15 via-transparent to-sand-400/10" />
+      <div className="relative flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-4">
+          <span className="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-gulf-500/15 text-gulf-700 dark:text-gulf-300">
+            <CalendarClock className="h-6 w-6" aria-hidden />
+          </span>
+          <div className="min-w-0">
+            <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-gulf-700 dark:text-gulf-300">
+              {eyebrow}
+            </p>
+            <p
+              className="mt-1 font-display text-xl font-semibold tracking-tight text-ink-900 sm:text-2xl dark:text-white"
+              suppressHydrationWarning
+            >
+              {localized}
+            </p>
+            <p
+              className="mt-1 text-sm text-ink-600 dark:text-ink-300"
+              suppressHydrationWarning
+            >
+              <span className="font-medium">{countdown}</span>
+              <span className="mx-1.5 text-ink-400">·</span>
+              7:30 - 10:00 PM ET every Monday
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <a
+            href="https://discord.gulfcoastmesh.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-primary"
+          >
+            Join on Discord
+            <ArrowUpRight className="h-4 w-4" aria-hidden />
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MountedNextMeetingCard() {
+  // Re-render every 60s so the "in X hours" countdown stays current. Setting
+  // state inside the interval callback is allowed by React 19's
+  // set-state-in-effect lint (it's a subscription, not an effect-body call).
+  const [now, setNow] = useState<Date>(() => new Date());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const next = computeNextMeeting(now);
+  return (
+    <Shell
+      eyebrow={next.inProgress ? "Meeting in progress" : "Next meeting"}
+      localized={formatLocal(next.start)}
+      countdown={formatCountdown(next.start, now)}
+    />
+  );
+}
+
+export function NextMeetingCard() {
+  const mounted = useHasMounted();
+  if (!mounted) {
+    return (
+      <Shell
+        eyebrow="Next meeting"
+        localized="Monday · 7:30 PM ET"
+        countdown="every week"
+      />
+    );
+  }
+  return <MountedNextMeetingCard />;
+}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -10,6 +10,7 @@ type NavItem = { label: string; href: string; external?: boolean };
 const nav: readonly NavItem[] = [
   { label: "Network", href: "/#network" },
   { label: "Maps", href: "/meshmap" },
+  { label: "Meetings", href: "/meetings" },
   { label: "Setup", href: "/setup" },
   { label: "Resources", href: "/links" },
   { label: "Newsletter", href: "/emailsignup" },

--- a/lib/meetings.ts
+++ b/lib/meetings.ts
@@ -1,0 +1,177 @@
+/**
+ * Server-only fetcher for the Gulf Coast Mesh published meeting archive.
+ *
+ * Source: https://meeting.gulfcoastmesh.org/api/public/meetings
+ * Contract: see PUBLIC_API.md in the repo root.
+ *
+ * Only published past meetings appear here. The endpoint is open / read-only;
+ * we cache for 5 minutes (matching the cadence used by lib/mesh-stats.ts) so
+ * the page stays snappy without hammering the export server.
+ */
+
+import "server-only";
+
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+import rehypeStringify from "rehype-stringify";
+
+export const MEETING_API_BASE = "https://meeting.gulfcoastmesh.org";
+const REVALIDATE_SECONDS = 300;
+
+export type PublicMeetingAgenda = {
+  originalName: string;
+  contentType: string;
+  uploadedAt: string;
+  size: number;
+  /** Relative path returned by the API. Prepend MEETING_API_BASE to fetch. */
+  downloadUrl: string;
+};
+
+export type PublicMeeting = {
+  id: string;
+  dateLabel: string;
+  startedAt: string;
+  endedAt: string;
+  youtubeUrl: string;
+  publishedAt: string;
+  agendas: PublicMeetingAgenda[];
+};
+
+type PublicMeetingsResponse = {
+  meetings?: PublicMeeting[];
+};
+
+/** Detail response — adds transcript + recap to the summary shape. */
+export type PublicMeetingDetail = PublicMeeting & {
+  transcript: string;
+  recap: string;
+};
+
+/** Past meeting plus rendered recap HTML, ready for direct injection. */
+export type PublicMeetingWithRecap = PublicMeeting & {
+  /** Sanitized HTML produced from the recap markdown. Empty when no recap
+   *  was returned for the meeting. */
+  recapHtml: string;
+};
+
+export async function getPublishedMeetings(): Promise<PublicMeeting[]> {
+  try {
+    const res = await fetch(`${MEETING_API_BASE}/api/public/meetings`, {
+      next: { revalidate: REVALIDATE_SECONDS, tags: ["meetings"] },
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as PublicMeetingsResponse;
+    if (!Array.isArray(json.meetings)) return [];
+    // Defensive: ensure agendas is always an array even if the upstream payload
+    // omits it for an older record.
+    return json.meetings.map((m) => ({
+      ...m,
+      agendas: Array.isArray(m.agendas) ? m.agendas : [],
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export async function getPublishedMeetingDetail(
+  id: string,
+): Promise<PublicMeetingDetail | null> {
+  try {
+    const res = await fetch(
+      `${MEETING_API_BASE}/api/public/meetings/${encodeURIComponent(id)}`,
+      { next: { revalidate: REVALIDATE_SECONDS, tags: ["meetings", `meeting:${id}`] } },
+    );
+    if (!res.ok) return null;
+    const detail = (await res.json()) as PublicMeetingDetail;
+    return {
+      ...detail,
+      agendas: Array.isArray(detail.agendas) ? detail.agendas : [],
+      transcript: typeof detail.transcript === "string" ? detail.transcript : "",
+      recap: typeof detail.recap === "string" ? detail.recap : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch the meeting list and then, in parallel, each meeting's recap markdown
+ * rendered to sanitized HTML.
+ *
+ * This is an N+1 request shape, but N is tiny (one row per published meeting,
+ * one meeting per week) and every leg is wrapped in Next.js' fetch cache, so
+ * in practice this resolves from the data cache on the hot path.
+ */
+export async function getPublishedMeetingsWithRecap(): Promise<PublicMeetingWithRecap[]> {
+  const summaries = await getPublishedMeetings();
+  if (summaries.length === 0) return [];
+  const enriched = await Promise.all(
+    summaries.map(async (m) => {
+      const detail = await getPublishedMeetingDetail(m.id);
+      const recapHtml = detail?.recap ? await renderRecapMarkdown(detail.recap) : "";
+      return { ...m, recapHtml };
+    }),
+  );
+  return enriched;
+}
+
+/**
+ * Render meeting recap markdown to safe HTML.
+ *
+ * Strict by design: no raw HTML pass-through (we don't `rehypeRaw`), no
+ * autolink-headings or slug plugins (these are card-sized excerpts, not
+ * standalone docs pages), and rehype-sanitize is locked to the default safe
+ * allowlist. The output is styled by `.prose-mesh` in app/globals.css.
+ */
+export async function renderRecapMarkdown(md: string): Promise<string> {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeSanitize, defaultSchema)
+    .use(rehypeStringify)
+    .process(md);
+  return String(file);
+}
+
+/** Turn the API's relative `downloadUrl` into an absolute URL. */
+export function absoluteAgendaUrl(downloadUrl: string): string {
+  if (/^https?:\/\//i.test(downloadUrl)) return downloadUrl;
+  const path = downloadUrl.startsWith("/") ? downloadUrl : `/${downloadUrl}`;
+  return `${MEETING_API_BASE}${path}`;
+}
+
+/**
+ * Format an ISO timestamp into a YYYY-MM-DD key in America/New_York.
+ *
+ * The meetings nominally run 7:30 - 10:00 PM ET on a Monday, which means a
+ * meeting that starts on Monday in ET will sometimes already be Tuesday in
+ * UTC. Bucketing by the ET calendar day keeps everything aligned with the
+ * Monday cell in the calendar regardless of the visitor's timezone.
+ */
+export function meetingDateKeyEt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  // en-CA gives ISO-shaped YYYY-MM-DD output via Intl.
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
+/** Format an ISO timestamp as a short time string in ET (e.g. "7:31 PM"). */
+export function formatTimeEt(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(d);
+}

--- a/lib/use-has-mounted.ts
+++ b/lib/use-has-mounted.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => {};
+
+/**
+ * Returns false during SSR + the first hydration render, then true afterwards.
+ *
+ * Useful for client components that need to defer timezone- or clock-dependent
+ * rendering until after hydration so the server and the first client render
+ * emit identical markup. Drop-in safer replacement for the legacy
+ * `useState(false) + useEffect(() => setState(true), [])` idiom — that
+ * pattern trips React 19's `set-state-in-effect` lint, this one does not.
+ */
+export function useHasMounted(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false,
+  );
+}

--- a/monitoring/ALERTS.md
+++ b/monitoring/ALERTS.md
@@ -1,0 +1,151 @@
+# Grafana Cloud Alert Rules
+
+Copy-paste-friendly definitions for the recommended alert rules. Add each
+one under **Alerts -> Alert rules -> New alert rule** in the Grafana Cloud
+UI. Pick *Grafana managed alert*. Point the data source at your
+`grafanacloud-<stack>-prom` Prometheus.
+
+The instance label assumes you kept `instance = "gulfcoast-mesh-vps"` in
+the Alloy scrape config (see `alloy-config.alloy.template`).
+
+## Contact point - do this first
+
+**Alerts -> Contact points -> + Add contact point**
+
+| Field         | Value                                                                                |
+|---------------|--------------------------------------------------------------------------------------|
+| Name          | `gcm-discord`                                                                        |
+| Integration   | Discord                                                                              |
+| Webhook URL   | Discord channel webhook from `https://discord.com/...settings...webhooks`.           |
+| Avatar URL    | (optional) the GCM logo                                                              |
+
+Test the webhook with the *Test* button. A message should land in the
+target Discord channel.
+
+Then **Alerts -> Notification policies -> Edit default policy** -> set the
+default contact point to `gcm-discord`. (You can also keep an email
+fallback by leaving the default as `email` and adding `gcm-discord` as a
+nested matcher for severity=critical, but that is a refinement, do it
+later.)
+
+---
+
+## Rule 1 - VPS is unreachable
+
+| Field         | Value                                                                       |
+|---------------|-----------------------------------------------------------------------------|
+| Name          | `vps host down`                                                             |
+| Folder        | `gcm-vps`                                                                   |
+| Eval group    | `gcm-vps` (interval 1m)                                                     |
+| Condition     | A is `0` (i.e. expression A returns the value 0)                            |
+| Expression A  | `up{instance="gulfcoast-mesh-vps", job="node_exporter"}`                    |
+| For           | `5m`                                                                        |
+| Severity      | `critical`                                                                  |
+| Summary       | VPS 152.53.83.210 not reporting metrics for 5 minutes.                      |
+| Description   | node_exporter scrape failing or Alloy dead. Check ssh access first.         |
+
+This fires when the collector stops shipping metrics for the VPS at all.
+
+---
+
+## Rule 2 - Disk filling up
+
+| Field         | Value                                                                                                                 |
+|---------------|-----------------------------------------------------------------------------------------------------------------------|
+| Name          | `vps disk low`                                                                                                        |
+| Folder        | `gcm-vps`                                                                                                             |
+| Eval group    | `gcm-vps`                                                                                                             |
+| Condition     | A < 0.10                                                                                                              |
+| Expression A  | `node_filesystem_avail_bytes{mountpoint="/", instance="gulfcoast-mesh-vps", fstype!~"tmpfs\|devtmpfs"} / node_filesystem_size_bytes{mountpoint="/", instance="gulfcoast-mesh-vps", fstype!~"tmpfs\|devtmpfs"}` |
+| For           | `1h`                                                                                                                  |
+| Severity      | `warning`                                                                                                             |
+| Summary       | / has less than 10% free for 1 hour.                                                                                  |
+| Description   | Investigate `du -h --max-depth=1 /` on the VPS. Usual suspects: Next.js .next cache, journald, docker images.         |
+
+Given the VPS started at 90% used, this is the most likely first-fire
+alert. The 1-hour `for` window keeps log-rotation spikes from paging.
+
+---
+
+## Rule 3 - Memory exhausted
+
+| Field         | Value                                                                                                            |
+|---------------|------------------------------------------------------------------------------------------------------------------|
+| Name          | `vps memory critical`                                                                                            |
+| Folder        | `gcm-vps`                                                                                                        |
+| Eval group    | `gcm-vps`                                                                                                        |
+| Condition     | A < 0.05                                                                                                         |
+| Expression A  | `node_memory_MemAvailable_bytes{instance="gulfcoast-mesh-vps"} / node_memory_MemTotal_bytes{instance="gulfcoast-mesh-vps"}` |
+| For           | `5m`                                                                                                             |
+| Severity      | `critical`                                                                                                       |
+| Summary       | Less than 5% available memory on the VPS for 5m.                                                                 |
+| Description   | OOM killer is likely about to fire. ssh in and run `ps auxf --sort=-rss \| head -20`.                            |
+
+---
+
+## Rule 4 - Sustained CPU saturation
+
+| Field         | Value                                                                                          |
+|---------------|------------------------------------------------------------------------------------------------|
+| Name          | `vps cpu sustained`                                                                            |
+| Folder        | `gcm-vps`                                                                                      |
+| Eval group    | `gcm-vps`                                                                                      |
+| Condition     | A > 2                                                                                          |
+| Expression A  | `node_load5{instance="gulfcoast-mesh-vps"}`                                                    |
+| For           | `15m`                                                                                          |
+| Severity      | `warning`                                                                                      |
+| Summary       | 5-minute load average > 2 (the VPS has 2 cores) for 15m.                                       |
+| Description   | Something pinned the CPUs. Check `top` and the Discord recap for any heavy job kicking off.    |
+
+Threshold `2` is hardcoded to the 2-core VPS spec in the system info you
+shared. If the VPS gets resized later, bump this in lockstep.
+
+---
+
+## Rule 5 - Collector cannot ship to Grafana Cloud
+
+| Field         | Value                                                                                                              |
+|---------------|--------------------------------------------------------------------------------------------------------------------|
+| Name          | `alloy remote_write failing`                                                                                       |
+| Folder        | `gcm-vps`                                                                                                          |
+| Eval group    | `gcm-vps`                                                                                                          |
+| Condition     | A > 0                                                                                                              |
+| Expression A  | `increase(prometheus_remote_storage_samples_failed_total{instance="gulfcoast-mesh-vps"}[10m])`                     |
+| For           | `15m`                                                                                                              |
+| Severity      | `warning`                                                                                                          |
+| Summary       | Alloy is failing to push samples to Grafana Cloud.                                                                 |
+| Description   | Probably a 401/403 (rotated token, scope dropped) or network blip. Check `journalctl -u alloy -n 200` on the VPS.  |
+
+Self-monitoring rule. If this fires, the other rules might be silently
+broken too because their data is not getting to the TSDB.
+
+---
+
+## Rule 6 - Website unreachable (placeholder, wire later)
+
+Not added in this pass - the Next.js site does not currently expose a
+`/metrics` endpoint or an external blackbox prober. To enable this in a
+follow-up, either:
+
+- Add the `prom-client` npm package and an `/api/metrics` route, then add
+  a `prometheus.scrape` block in the Alloy config pointing at it; **or**
+- Use Grafana Cloud's hosted **Synthetic Monitoring** (free tier, no
+  collector changes needed) to ping `https://gulfcoastmesh.org` from
+  multiple regions every 60s.
+
+---
+
+## Test fire
+
+Easiest way to confirm the contact point + a real rule both work end-to-
+end:
+
+1. Temporarily edit Rule 3 (memory) to `> 0` (i.e. *any* memory available
+   triggers).
+2. Save. Wait 5 min for the `for:` window.
+3. Confirm Discord (or email) gets a message titled
+   `[FIRING] vps memory critical`.
+4. Revert Rule 3 back to `< 0.05`.
+
+Do this once on initial setup so you know alerting is wired up before you
+need it.

--- a/monitoring/INSTALL.md
+++ b/monitoring/INSTALL.md
@@ -1,0 +1,374 @@
+# VPS Monitoring - Grafana Cloud Collector
+
+Runbook for installing the metrics + logs collector on the Gulf Coast Mesh
+production VPS (`152.53.83.210`, Debian 13) so it ships to your existing
+Grafana Cloud org. Nothing about Grafana / Prometheus / Alertmanager itself
+runs on the VPS - those are hosted by Grafana Cloud.
+
+## What lands on the VPS
+
+```
+/usr/local/bin/node_exporter                      # system metrics agent
+/etc/systemd/system/node_exporter.service         # systemd unit (we write it)
+/etc/apt/sources.list.d/grafana.list              # Grafana apt repo
+/etc/apt/keyrings/grafana.gpg                     # apt repo signing key
+/etc/alloy/config.alloy                           # collector config (with token)
+/etc/systemd/system/alloy.service                 # installed by the alloy package
+/var/lib/alloy/                                   # collector WAL working dir
+```
+
+Combined resident set on the VPS: ~80-120 MiB RAM, ~100 MiB disk.
+
+## File map in this folder
+
+| File                                        | What it is                                                                                          |
+|---------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| `INSTALL.md`                                | This runbook.                                                                                       |
+| `ALERTS.md`                                 | Section 6 expanded - one-table-per-alert reference for the Grafana Cloud Alerts UI.                 |
+| `alloy-config.alloy.template`               | Full collector config (metrics + logs). Has `__PROM_*__` / `__LOKI_*__` placeholders the renderer fills. |
+| `alloy-config.metrics-only.alloy.template`  | Metrics-only variant for when you do not yet have a Loki write token. Renderer picks it via `--metrics-only`. |
+| `scripts/preflight.sh`                      | Pre-install audit. Run on the VPS first. Pass/fail gate on disk usage.                              |
+| `scripts/install-collector.sh`              | One-shot installer. Idempotent. Handles node_exporter + Alloy apt install + service enable.         |
+| `scripts/render-alloy-config.sh`            | Reads creds from env vars, renders the template into a real config file ready to copy onto the VPS. |
+
+---
+
+## Section 0 - Gather Grafana Cloud credentials
+
+The stack is **`gulfcoastmesh.grafana.net`** (Instance ID `1665176`, region
+`prod-eu-west-2`). The collector on the VPS needs these per-destination
+strings:
+
+```
+PROM_URL       = https://prometheus-prod-65-prod-eu-west-2.grafana.net/api/prom/push
+PROM_USERNAME  = 3254576           # numeric Instance ID for hosted Prometheus
+PROM_TOKEN     = glc_...            # token with metrics:write scope
+
+LOKI_URL       = https://logs-prod-012.grafana.net/loki/api/v1/push
+LOKI_USERNAME  = 1622963           # numeric Instance ID for hosted Loki
+LOKI_TOKEN     = glc_...            # token with logs:write scope
+```
+
+The `PROM_URL`, `PROM_USERNAME`, `LOKI_URL`, `LOKI_USERNAME` values above
+are the ones pulled from this stack and can be used as-is. **Only the two
+tokens need to be obtained.**
+
+### About the tokens
+
+Grafana Cloud's "Data Source settings" page shows you a **read-only** token
+for each data source (used by Grafana itself to query). Alloy needs **write**
+tokens. You have two choices:
+
+**Option A - one access-policy token covering both destinations (simpler).**
+This is what the rest of this runbook assumes when it says "the token".
+
+1. Cloud Portal -> **Access Policies** -> *Create access policy*.
+2. Name: `gulfcoast-mesh-vps`.
+3. Realms: leave default (your stack).
+4. Scopes: tick `metrics:write` **and** `logs:write`. Nothing else.
+5. Save, then on the policy row click *Add token*. Name: `vps-alloy`.
+6. Copy the token now (shown once). Set both `PROM_TOKEN` and `LOKI_TOKEN`
+   to this same value, or just set `CLOUD_TOKEN` and the renderer fills
+   both for you.
+
+**Option B - separate write-only data-source tokens (least privilege).**
+On the Cloud Portal, click "Send Metrics" on the Prometheus tile and "Send
+Logs" on the Loki tile. Each page offers to generate a token whose name
+ends in `-write-prometheus-api` or `-write-loki-api`. Use those values for
+`PROM_TOKEN` and `LOKI_TOKEN` respectively.
+
+The renderer (`scripts/render-alloy-config.sh`) sanity-checks the token
+names and refuses to proceed if it sees a `-read-` token in a write slot,
+so you cannot accidentally deploy with the wrong scope.
+
+### If you do not have a Loki write token yet
+
+You can still deploy **metrics today** and add logs later. Render with
+`--metrics-only` (Section 4), and when you have the Loki write token,
+re-render with the full template and `systemctl restart alloy`. No data
+loss - metric names and labels stay identical across both configs.
+
+### Security note
+
+If you paste a Grafana Cloud token anywhere it does not belong (chat,
+email, screenshots, public docs), revoke it from Cloud Portal -> Access
+Policies -> Tokens and reissue. Tokens are bearer credentials - whoever
+has the string can write metrics/logs as you.
+
+---
+
+## Section 1 - Pre-flight on the VPS
+
+```bash
+ssh root@152.53.83.210
+
+# Confirm distro is what we expect
+grep -E '^(NAME|VERSION)=' /etc/os-release
+
+# Keep the base system current before adding packages
+apt update && apt upgrade -y
+
+# Audit disk - your last fastfetch showed / at 90%
+df -h /
+du -h --max-depth=1 / 2>/dev/null | sort -h | tail -20
+
+# Low-risk reclaim. After this, df -h / again.
+journalctl --vacuum-time=14d
+apt autoremove --purge -y
+apt clean
+df -h /
+```
+
+**Gate**: if `/` is still above 85% after the cleanup, stop and investigate.
+Common culprits on a Next.js host:
+
+- `~/development/.next/` build caches (`du -sh ~/development/.next`)
+- Docker images if any (`docker system df`, then `docker system prune -a`)
+- Stale `node_modules` trees (`du -sh ~/*/node_modules`)
+- Old kernels (`apt list --installed | grep linux-image`)
+
+We do not want to install Alloy on a host that is one log rotation away
+from a full disk.
+
+---
+
+## Section 2 - Install node_exporter v1.11.1
+
+Binds to **`127.0.0.1:9100` only**. Never exposed to the public internet.
+The Alloy collector scrapes it locally.
+
+You have two ways to run this section: paste each command into the SSH
+session by hand, or scp `scripts/install-collector.sh` up and run it.
+The script is idempotent - re-running it is safe.
+
+### Manual
+
+```bash
+NE_VER=1.11.1
+cd /tmp
+wget -q "https://github.com/prometheus/node_exporter/releases/download/v${NE_VER}/node_exporter-${NE_VER}.linux-amd64.tar.gz"
+tar xzf "node_exporter-${NE_VER}.linux-amd64.tar.gz"
+install -o root -g root -m 0755 "node_exporter-${NE_VER}.linux-amd64/node_exporter" /usr/local/bin/node_exporter
+useradd --system --no-create-home --shell /usr/sbin/nologin node_exporter || true
+
+cat > /etc/systemd/system/node_exporter.service <<'EOF'
+[Unit]
+Description=Prometheus node_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=node_exporter
+Group=node_exporter
+Type=simple
+ExecStart=/usr/local/bin/node_exporter \
+  --web.listen-address=127.0.0.1:9100 \
+  --collector.systemd \
+  --collector.processes
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now node_exporter
+systemctl status node_exporter --no-pager
+curl -s http://127.0.0.1:9100/metrics | head -n 5
+```
+
+**Expected**: `active (running)` and `curl` returns lines starting with
+`# HELP go_gc_duration_seconds ...`.
+
+---
+
+## Section 3 - Install Grafana Alloy
+
+```bash
+mkdir -p /etc/apt/keyrings
+wget -qO- https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
+echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" \
+  > /etc/apt/sources.list.d/grafana.list
+apt update
+apt install -y alloy
+systemctl status alloy --no-pager
+```
+
+The apt package ships with `/etc/alloy/config.alloy` pre-installed as an
+empty example. We replace it in the next section.
+
+---
+
+## Section 4 - Render and install the Alloy config
+
+This is the only step that touches the credentials.
+
+### 4a. Pick a mode
+
+| Situation                                              | Command                                              |
+|--------------------------------------------------------|------------------------------------------------------|
+| You have **both** a metrics-write and logs-write token | `./scripts/render-alloy-config.sh`                   |
+| You have **only** a metrics-write token (logs later)   | `./scripts/render-alloy-config.sh --metrics-only`    |
+
+### 4b. Render on your laptop
+
+```bash
+cd /home/mrsharky/Documents/Agent-AI-Workspace/GulfcoastMeshWebsite/development/monitoring
+
+# Values for the gulfcoastmesh.grafana.net stack (from Section 0)
+export PROM_URL='https://prometheus-prod-65-prod-eu-west-2.grafana.net/api/prom/push'
+export PROM_USERNAME='3254576'
+export PROM_TOKEN='glc_...your_metrics_write_token...'
+
+# Full mode only - skip if you are running --metrics-only
+export LOKI_URL='https://logs-prod-012.grafana.net/loki/api/v1/push'
+export LOKI_USERNAME='1622963'
+export LOKI_TOKEN='glc_...your_logs_write_token...'
+
+# If you used Option A (one access-policy token), set this instead of
+# the two *_TOKEN vars - the renderer falls back to it:
+# export CLOUD_TOKEN='glc_...both_scopes...'
+
+./scripts/render-alloy-config.sh > /tmp/config.alloy        # full mode
+# or
+./scripts/render-alloy-config.sh --metrics-only > /tmp/config.alloy
+
+scp /tmp/config.alloy root@152.53.83.210:/etc/alloy/config.alloy
+
+# Wipe the rendered copy - it contains a token
+shred -u /tmp/config.alloy
+```
+
+The renderer refuses to emit if:
+
+- A required env var is unset (with a clear message about which).
+- Any `__PLACEHOLDER__` survives the substitution.
+- A `*_TOKEN` value is actually a Grafana Cloud read-only data-source
+  token (it inspects the embedded name and bails out).
+
+### 4c. Apply on the VPS
+
+```bash
+ssh root@152.53.83.210
+
+chown root:alloy /etc/alloy/config.alloy
+chmod 0640 /etc/alloy/config.alloy
+alloy fmt /etc/alloy/config.alloy >/dev/null   # exits non-zero on syntax errors
+systemctl restart alloy
+systemctl status alloy --no-pager
+journalctl -u alloy -n 80 --no-pager
+```
+
+Look in the journal for:
+
+- `started component prometheus.remote_write.grafana_cloud`
+- `started component loki.write.grafana_cloud` *(full mode only)*
+- No `401`/`403`/`unauthorized` lines
+- No `dial tcp ... no such host` lines (would mean a typo in the URL)
+
+### 4d. (Optional) Edit on the VPS directly
+
+If you would rather not move the rendered config over scp, paste the
+relevant template contents into `nano /etc/alloy/config.alloy` and hand-
+replace each `__...__` marker. Then run the `chown` / `chmod` / `alloy fmt`
+/ `systemctl restart` sequence from 4c.
+
+---
+
+## Section 5 - Verify in Grafana Cloud
+
+In <https://gulfcoastmesh.grafana.net>:
+
+1. **Explore** -> data source `gulfcoastmesh-prom` -> run each:
+   - `up{instance="gulfcoast-mesh-vps"}` -> should return `1`.
+   - `node_memory_MemAvailable_bytes{host="gulfcoast-mesh-vps"}` -> plots.
+   - `node_filesystem_avail_bytes{mountpoint="/",host="gulfcoast-mesh-vps"}` -> plots.
+
+2. **Explore** -> data source `grafanacloud-gulfcoastmesh-logs` -> run
+   *(full mode only - skip if you rendered with `--metrics-only`)*:
+   - `{host="gulfcoast-mesh-vps"}` -> recent journald lines stream in.
+
+3. **Dashboards** -> *New* -> *Import*:
+   - ID `1860` ("Node Exporter Full") - pick the `gulfcoastmesh-prom` DS.
+   - ID `20696` ("Alloy meta-monitoring") - collector self-health.
+
+If `up` is `0`:
+
+- `journalctl -u alloy -n 200 --no-pager` and look for `401`/`403` (token
+  scope missing) or DNS errors (URL typo).
+- Make sure the access policy token has **both** `metrics:write` and
+  `logs:write` checked, not just one.
+- The Prometheus username goes with the Prometheus URL, the Loki username
+  with the Loki URL - it is easy to swap them by mistake.
+
+---
+
+## Section 6 - Recommended alert rules (Grafana Cloud UI)
+
+See **`ALERTS.md`** in this folder for the full, table-per-rule
+reference (contact point, six recommended rules, end-to-end test fire).
+The short version:
+
+| Alert                       | Trips on                                                                                | For   |
+|-----------------------------|------------------------------------------------------------------------------------------|-------|
+| `vps host down`             | `up{instance="gulfcoast-mesh-vps", job="node_exporter"} == 0`                            | 5m    |
+| `vps disk low`              | `/` filesystem available < 10%                                                           | 1h    |
+| `vps memory critical`       | `MemAvailable / MemTotal < 0.05`                                                         | 5m    |
+| `vps cpu sustained`         | `node_load5 > 2` (the VPS has 2 cores)                                                   | 15m   |
+| `alloy remote_write failing`| `increase(prometheus_remote_storage_samples_failed_total[10m]) > 0`                      | 15m   |
+
+Wire a contact point under **Alerts** -> *Contact points*. Discord
+webhook is easiest - paste the URL from the GCM Discord channel settings.
+
+---
+
+## Section 7 - Source zips you already downloaded
+
+`/home/mrsharky/Documents/Agent-AI-Workspace/GulfcoastMeshWebsite/server-monitoring/`
+contains upstream source code, not runnable binaries:
+
+- `prometheus-3.11.3.zip` - **not used**; Grafana Cloud's hosted
+  Prometheus is the TSDB.
+- `grafana-13.0.1-security-01.zip` - **not used**; Grafana Cloud is the
+  UI.
+- `alertmanager-0.32.1.zip` - **not used**; Grafana Cloud alerting takes
+  the role.
+- `node_exporter-1.11.1.zip` - the binary we install in Section 2 is the
+  same version cut from the same release.
+
+You can keep the zips for offline reference or remove them. They are not
+referenced by anything on the VPS.
+
+---
+
+## Rollback
+
+If something breaks and you want the VPS back exactly as it was:
+
+```bash
+# Stop and remove the services
+systemctl disable --now alloy node_exporter
+rm /etc/systemd/system/node_exporter.service
+systemctl daemon-reload
+
+# Uninstall packages
+apt remove --purge -y alloy
+apt autoremove --purge -y
+
+# Drop config + binary + user
+rm -rf /etc/alloy /var/lib/alloy
+rm /usr/local/bin/node_exporter
+userdel node_exporter
+
+# Drop the apt repo
+rm /etc/apt/sources.list.d/grafana.list /etc/apt/keyrings/grafana.gpg
+apt update
+```
+
+After this the VPS is byte-identical to its pre-monitoring state apart
+from any apt updates picked up during Section 1.

--- a/monitoring/alloy-config.alloy.template
+++ b/monitoring/alloy-config.alloy.template
@@ -1,0 +1,86 @@
+// Grafana Alloy config for the Gulf Coast Mesh production VPS.
+// Renders to /etc/alloy/config.alloy. Do not commit the rendered version -
+// it contains a Grafana Cloud write token.
+//
+// Placeholders (filled by render-alloy-config.sh from env vars):
+//   <PROM_URL>           hosted Prometheus remote_write URL
+//   <PROM_USERNAME>      hosted Prometheus instance ID (numeric)
+//   <PROM_TOKEN>         token with metrics:write scope (glc_...)
+//   <LOKI_URL>           hosted Loki push URL
+//   <LOKI_USERNAME>      hosted Loki instance ID (numeric)
+//   <LOKI_TOKEN>         token with logs:write scope (glc_...)
+//
+// PROM_TOKEN and LOKI_TOKEN can be the same value (one access-policy
+// token with both scopes) or different values (one write-only data-
+// source token per destination - least privilege).
+
+// ---------------------------------------------------------------------------
+// 1. node_exporter scrape -> hosted Prometheus
+// ---------------------------------------------------------------------------
+
+prometheus.scrape "node_exporter" {
+  targets = [
+    { __address__ = "127.0.0.1:9100", instance = "gulfcoast-mesh-vps" },
+  ]
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+  scrape_interval = "60s"
+  job_name        = "node_exporter"
+}
+
+// ---------------------------------------------------------------------------
+// 2. Alloy self-metrics scrape -> hosted Prometheus
+//    Lets you watch the collector itself in Grafana (queue depth, WAL size,
+//    remote_write retries). Cheap, ~30 series.
+// ---------------------------------------------------------------------------
+
+prometheus.exporter.self "alloy" {}
+
+prometheus.scrape "alloy_self" {
+  targets         = prometheus.exporter.self.alloy.targets
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+  scrape_interval = "60s"
+  job_name        = "alloy"
+}
+
+// ---------------------------------------------------------------------------
+// 3. Remote write to Grafana Cloud hosted Prometheus
+// ---------------------------------------------------------------------------
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = "__PROM_URL__"
+    basic_auth {
+      username = "__PROM_USERNAME__"
+      password = "__PROM_TOKEN__"
+    }
+  }
+  external_labels = {
+    host = "gulfcoast-mesh-vps",
+    env  = "prod",
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. systemd journal -> hosted Loki
+//    Streams journald straight up. max_age = "12h" caps how far back we
+//    will pull on a cold start so a restart does not republish weeks of logs.
+// ---------------------------------------------------------------------------
+
+loki.source.journal "system" {
+  forward_to = [loki.write.grafana_cloud.receiver]
+  labels = {
+    job  = "systemd-journal",
+    host = "gulfcoast-mesh-vps",
+  }
+  max_age = "12h"
+}
+
+loki.write "grafana_cloud" {
+  endpoint {
+    url = "__LOKI_URL__"
+    basic_auth {
+      username = "__LOKI_USERNAME__"
+      password = "__LOKI_TOKEN__"
+    }
+  }
+}

--- a/monitoring/alloy-config.metrics-only.alloy.template
+++ b/monitoring/alloy-config.metrics-only.alloy.template
@@ -1,0 +1,46 @@
+// Grafana Alloy config - metrics-only variant.
+//
+// Use this when you have a Prometheus write token (hm-write-prometheus-api
+// or an access-policy token with metrics:write) but do NOT yet have a Loki
+// write token. node_exporter metrics + Alloy self-metrics ship to Grafana
+// Cloud; no logs are collected or pushed.
+//
+// When you later obtain a Loki write token, switch to the full
+// alloy-config.alloy.template - the metrics blocks below are identical.
+//
+// Placeholders (filled by render-alloy-config.sh from env vars):
+//   <PROM_URL>           hosted Prometheus remote_write URL
+//   <PROM_USERNAME>      hosted Prometheus instance ID (numeric)
+//   <PROM_TOKEN>         token with metrics:write scope (glc_...)
+
+prometheus.scrape "node_exporter" {
+  targets = [
+    { __address__ = "127.0.0.1:9100", instance = "gulfcoast-mesh-vps" },
+  ]
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+  scrape_interval = "60s"
+  job_name        = "node_exporter"
+}
+
+prometheus.exporter.self "alloy" {}
+
+prometheus.scrape "alloy_self" {
+  targets         = prometheus.exporter.self.alloy.targets
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+  scrape_interval = "60s"
+  job_name        = "alloy"
+}
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = "__PROM_URL__"
+    basic_auth {
+      username = "__PROM_USERNAME__"
+      password = "__PROM_TOKEN__"
+    }
+  }
+  external_labels = {
+    host = "gulfcoast-mesh-vps",
+    env  = "prod",
+  }
+}

--- a/monitoring/scripts/install-collector.sh
+++ b/monitoring/scripts/install-collector.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# install-collector.sh - Install node_exporter v1.11.1 and Grafana Alloy on
+# a Debian 13 host. Run as root on the VPS after preflight.sh has passed.
+#
+# Idempotent: safe to re-run. Each step checks current state and skips work
+# that is already done. Does NOT write /etc/alloy/config.alloy - that ships
+# separately from this folder (see Section 4 of INSTALL.md) so the access
+# token never has to live in this repo.
+#
+# After this script exits successfully:
+#   * node_exporter is running, bound to 127.0.0.1:9100
+#   * Alloy is installed and running with whatever config is already at
+#     /etc/alloy/config.alloy (the apt default if you have not replaced it
+#     yet - that is fine, just drop in the real one and `systemctl restart
+#     alloy` afterwards)
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "install-collector: must run as root (try: sudo $0)" >&2
+  exit 2
+fi
+
+NE_VERSION="1.11.1"
+NE_BIN="/usr/local/bin/node_exporter"
+NE_UNIT="/etc/systemd/system/node_exporter.service"
+NE_ARCH="linux-amd64"
+NE_TARBALL="node_exporter-${NE_VERSION}.${NE_ARCH}.tar.gz"
+NE_URL="https://github.com/prometheus/node_exporter/releases/download/v${NE_VERSION}/${NE_TARBALL}"
+NE_SHA256="9f5ea48e5bc7b656f8a91a32e7d7deb89f70f73dabd0d974418aca15f37d6810"
+# ^ official linux-amd64 release shasum from prometheus/node_exporter v1.11.1
+#   sha256sums.txt. If you ever bump NE_VERSION, refresh this from:
+#     https://github.com/prometheus/node_exporter/releases/download/v<VER>/sha256sums.txt
+
+banner() {
+  printf '\n=== %s ===\n' "$1"
+}
+
+##############################################################################
+# 1. node_exporter
+##############################################################################
+
+banner "node_exporter v${NE_VERSION}"
+
+INSTALLED_VERSION=""
+if [[ -x "${NE_BIN}" ]]; then
+  INSTALLED_VERSION="$("${NE_BIN}" --version 2>&1 | awk '/node_exporter, version/ {print $3; exit}')"
+fi
+
+if [[ "${INSTALLED_VERSION}" == "${NE_VERSION}" ]]; then
+  echo "node_exporter ${NE_VERSION} already installed at ${NE_BIN}. Skipping download."
+else
+  if [[ -n "${INSTALLED_VERSION}" ]]; then
+    echo "Replacing node_exporter ${INSTALLED_VERSION} with ${NE_VERSION}."
+  else
+    echo "Installing node_exporter ${NE_VERSION}."
+  fi
+  cd /tmp
+  wget -q --show-progress "${NE_URL}" -O "${NE_TARBALL}"
+  echo "${NE_SHA256}  ${NE_TARBALL}" | sha256sum -c -
+  tar xzf "${NE_TARBALL}"
+  install -o root -g root -m 0755 "node_exporter-${NE_VERSION}.${NE_ARCH}/node_exporter" "${NE_BIN}"
+  rm -rf "/tmp/node_exporter-${NE_VERSION}.${NE_ARCH}" "/tmp/${NE_TARBALL}"
+fi
+
+if ! id node_exporter >/dev/null 2>&1; then
+  useradd --system --no-create-home --shell /usr/sbin/nologin node_exporter
+fi
+
+cat > "${NE_UNIT}" <<'EOF'
+[Unit]
+Description=Prometheus node_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=node_exporter
+Group=node_exporter
+Type=simple
+ExecStart=/usr/local/bin/node_exporter \
+  --web.listen-address=127.0.0.1:9100 \
+  --collector.systemd \
+  --collector.processes
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now node_exporter
+systemctl restart node_exporter   # pick up unit changes on re-runs
+
+# Smoke test - the metrics endpoint should answer on localhost.
+for i in 1 2 3 4 5; do
+  if curl -fs -o /dev/null http://127.0.0.1:9100/metrics; then
+    echo "node_exporter is answering on 127.0.0.1:9100."
+    break
+  fi
+  echo "Waiting for node_exporter to bind (attempt ${i}/5)..."
+  sleep 1
+done
+
+if ! curl -fs -o /dev/null http://127.0.0.1:9100/metrics; then
+  echo "ERROR: node_exporter did not come up. Check: systemctl status node_exporter" >&2
+  exit 1
+fi
+
+##############################################################################
+# 2. Grafana Alloy (via the official Grafana apt repo)
+##############################################################################
+
+banner "Grafana Alloy"
+
+if ! command -v gpg >/dev/null 2>&1; then
+  apt-get update
+  apt-get install -y gnupg
+fi
+
+install -d -m 0755 /etc/apt/keyrings
+if [[ ! -s /etc/apt/keyrings/grafana.gpg ]]; then
+  wget -qO- https://apt.grafana.com/gpg.key | gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
+  chmod 0644 /etc/apt/keyrings/grafana.gpg
+fi
+
+if [[ ! -s /etc/apt/sources.list.d/grafana.list ]]; then
+  echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" \
+    > /etc/apt/sources.list.d/grafana.list
+fi
+
+apt-get update
+apt-get install -y alloy
+
+systemctl enable --now alloy
+
+banner "Status"
+systemctl --no-pager status node_exporter | sed -n '1,5p'
+systemctl --no-pager status alloy         | sed -n '1,5p'
+
+cat <<EOF
+
+install-collector: DONE.
+
+What you have now:
+  * node_exporter ${NE_VERSION} bound to 127.0.0.1:9100  (active)
+  * alloy installed and running with the apt default config
+
+Next:
+  1. From your laptop, render the real Alloy config (see INSTALL.md Sec. 4):
+       cd /home/mrsharky/Documents/Agent-AI-Workspace/GulfcoastMeshWebsite/development/monitoring
+       export PROM_URL=... PROM_USERNAME=... PROM_TOKEN=...
+       export LOKI_URL=... LOKI_USERNAME=... LOKI_TOKEN=...
+       # (or set CLOUD_TOKEN once if you used one access-policy token)
+       ./scripts/render-alloy-config.sh > /tmp/config.alloy
+       # OR if you do not have a Loki write token yet:
+       # ./scripts/render-alloy-config.sh --metrics-only > /tmp/config.alloy
+       scp /tmp/config.alloy root@152.53.83.210:/etc/alloy/config.alloy
+       shred -u /tmp/config.alloy
+
+  2. Back on the VPS:
+       chown root:alloy /etc/alloy/config.alloy
+       chmod 0640 /etc/alloy/config.alloy
+       alloy fmt /etc/alloy/config.alloy >/dev/null
+       systemctl restart alloy
+       journalctl -u alloy -n 80 --no-pager
+
+EOF

--- a/monitoring/scripts/preflight.sh
+++ b/monitoring/scripts/preflight.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# preflight.sh - VPS pre-install audit for the Grafana Cloud collector.
+#
+# Run as root on the target VPS. Idempotent, read-mostly. The only state-
+# changing actions are apt update/upgrade, journal vacuum, and apt clean -
+# all of which we want anyway before adding new packages.
+#
+# Exits with code 0 if the host is ready for Section 2 of INSTALL.md,
+# exit 1 if disk usage on / stays above 85% after cleanup (which means
+# you must investigate before going further).
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "preflight: must run as root (try: sudo $0)" >&2
+  exit 2
+fi
+
+DISK_GATE_PERCENT=85
+
+banner() {
+  printf '\n=== %s ===\n' "$1"
+}
+
+banner "Distro check"
+grep -E '^(NAME|VERSION|VERSION_ID)=' /etc/os-release
+
+banner "Apt update + upgrade"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' upgrade
+
+banner "Disk usage (before cleanup)"
+df -h /
+
+banner "Top space consumers under / (this can take a minute)"
+du -h --max-depth=1 / 2>/dev/null | sort -h | tail -20
+
+banner "Reclaiming low-risk space"
+journalctl --vacuum-time=14d || true
+apt-get autoremove --purge -y
+apt-get clean
+
+banner "Disk usage (after cleanup)"
+df -h /
+
+USED_PERCENT="$(df --output=pcent / | tail -n1 | tr -d ' %')"
+echo
+echo "Root filesystem is at ${USED_PERCENT}% used."
+
+if (( USED_PERCENT > DISK_GATE_PERCENT )); then
+  cat <<EOF >&2
+
+preflight: GATE FAILED.
+
+/ is still above ${DISK_GATE_PERCENT}% after cleanup. Common culprits to
+investigate before installing more services on this host:
+
+  * Next.js build cache:        du -sh ~/development/.next
+  * Docker images (if any):     docker system df
+  * Stale node_modules:         du -sh ~/*/node_modules 2>/dev/null
+  * Old kernels:                apt list --installed 2>/dev/null | grep linux-image
+
+EOF
+  exit 1
+fi
+
+cat <<EOF
+
+preflight: PASS. The host is ready for Section 2 of INSTALL.md.
+
+Next:
+  bash install-collector.sh
+
+EOF

--- a/monitoring/scripts/render-alloy-config.sh
+++ b/monitoring/scripts/render-alloy-config.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# render-alloy-config.sh - Substitute Grafana Cloud credentials into the
+# alloy-config.alloy.template (or the metrics-only variant) and emit the
+# rendered config on stdout.
+#
+# Run on your laptop, not the VPS. The output contains a write token, so
+# pipe it straight to scp / shred and do not save it anywhere.
+#
+# Usage:
+#   export PROM_URL=https://prometheus-prod-...
+#   export PROM_USERNAME=1234567
+#   export PROM_TOKEN=glc_...metrics-write...
+#   export LOKI_URL=https://logs-prod-.../loki/api/v1/push
+#   export LOKI_USERNAME=1234567
+#   export LOKI_TOKEN=glc_...logs-write...
+#   ./render-alloy-config.sh > /tmp/config.alloy
+#
+# Short forms:
+#   * If you only have one access-policy token covering both metrics:write
+#     and logs:write, set CLOUD_TOKEN instead and leave PROM_TOKEN/LOKI_TOKEN
+#     unset; both will fall back to CLOUD_TOKEN.
+#   * If you do NOT yet have a Loki write token, pass --metrics-only to
+#     emit a metrics-only config (LOKI_* env vars are then ignored).
+#
+# After rendering:
+#   scp /tmp/config.alloy root@152.53.83.210:/etc/alloy/config.alloy
+#   shred -u /tmp/config.alloy
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONITORING_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+mode="full"
+for arg in "$@"; do
+  case "$arg" in
+    --metrics-only) mode="metrics-only" ;;
+    --full)         mode="full" ;;
+    -h|--help)
+      sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "render-alloy-config: unknown arg: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$mode" in
+  full)         template="${MONITORING_DIR}/alloy-config.alloy.template" ;;
+  metrics-only) template="${MONITORING_DIR}/alloy-config.metrics-only.alloy.template" ;;
+esac
+
+if [[ ! -f "${template}" ]]; then
+  echo "render-alloy-config: template not found at ${template}" >&2
+  exit 1
+fi
+
+# Token fallback: CLOUD_TOKEN covers both PROM_TOKEN and LOKI_TOKEN if either
+# is unset. Lets people who created one access-policy token with both scopes
+# (the simple path) set CLOUD_TOKEN once.
+: "${PROM_TOKEN:=${CLOUD_TOKEN:-}}"
+if [[ "$mode" == "full" ]]; then
+  : "${LOKI_TOKEN:=${CLOUD_TOKEN:-}}"
+fi
+
+required=(PROM_URL PROM_USERNAME PROM_TOKEN)
+if [[ "$mode" == "full" ]]; then
+  required+=(LOKI_URL LOKI_USERNAME LOKI_TOKEN)
+fi
+
+missing=()
+for var in "${required[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    missing+=("${var}")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  {
+    echo "render-alloy-config: missing required env vars (mode=${mode}):"
+    printf '  %s\n' "${missing[@]}"
+    echo
+    echo "Set them in your shell first, then re-run. See INSTALL.md section 0."
+    if [[ "$mode" == "full" && -z "${LOKI_TOKEN:-}" ]]; then
+      echo
+      echo "If you do not have a Loki write token yet, re-run with --metrics-only"
+      echo "to emit a config that ships metrics only."
+    fi
+  } >&2
+  exit 2
+fi
+
+# Quick sanity check: Grafana Cloud tokens start with `glc_`. Anything else
+# is almost certainly a copy-paste error or a deprecated key.
+for v in PROM_TOKEN LOKI_TOKEN; do
+  val="${!v:-}"
+  if [[ -n "$val" ]] && [[ ! "$val" =~ ^glc_ ]]; then
+    echo "render-alloy-config: WARNING - ${v} does not start with 'glc_'. Make sure you pasted a Grafana Cloud token, not an old-style API key." >&2
+  fi
+done
+
+# Read-scope detection. Grafana Cloud's auto-provisioned data-source tokens
+# embed a name like `hl-read-loki-api` / `hm-write-prometheus-api` in the
+# base64 payload after the glc_ prefix. We can decode and warn if the user
+# pasted a read-only token where we need write.
+warn_if_read_only() {
+  local var="$1" want_scope="$2"
+  local val="${!var:-}"
+  [[ -z "$val" ]] && return 0
+  local body name
+  body="$(printf '%s' "$val" | sed 's/^glc_//')"
+  # Tolerate missing padding by adding up to 2 `=`s.
+  while (( ${#body} % 4 != 0 )); do body+='='; done
+  name="$(printf '%s' "$body" | base64 -d 2>/dev/null | sed -n 's/.*"n":"\([^"]*\)".*/\1/p')"
+  if [[ -n "$name" && "$name" == *"-read-"* ]]; then
+    echo "render-alloy-config: ERROR - ${var} appears to be a READ-only token (\"${name}\"). Alloy needs ${want_scope}. See INSTALL.md section 0." >&2
+    return 1
+  fi
+  return 0
+}
+
+read_check_ok=1
+warn_if_read_only PROM_TOKEN "metrics:write" || read_check_ok=0
+if [[ "$mode" == "full" ]]; then
+  warn_if_read_only LOKI_TOKEN "logs:write" || read_check_ok=0
+fi
+if (( read_check_ok == 0 )); then
+  exit 3
+fi
+
+# Escape any `&` or `/` that appear in values - they have meaning in sed
+# replacement text.
+escape() {
+  printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
+}
+
+PROM_URL_ESC="$(escape "${PROM_URL}")"
+PROM_USERNAME_ESC="$(escape "${PROM_USERNAME}")"
+PROM_TOKEN_ESC="$(escape "${PROM_TOKEN}")"
+
+sed_args=(
+  -e "s/__PROM_URL__/${PROM_URL_ESC}/g"
+  -e "s/__PROM_USERNAME__/${PROM_USERNAME_ESC}/g"
+  -e "s/__PROM_TOKEN__/${PROM_TOKEN_ESC}/g"
+)
+
+if [[ "$mode" == "full" ]]; then
+  LOKI_URL_ESC="$(escape "${LOKI_URL}")"
+  LOKI_USERNAME_ESC="$(escape "${LOKI_USERNAME}")"
+  LOKI_TOKEN_ESC="$(escape "${LOKI_TOKEN}")"
+  sed_args+=(
+    -e "s/__LOKI_URL__/${LOKI_URL_ESC}/g"
+    -e "s/__LOKI_USERNAME__/${LOKI_USERNAME_ESC}/g"
+    -e "s/__LOKI_TOKEN__/${LOKI_TOKEN_ESC}/g"
+  )
+fi
+
+rendered="$(sed "${sed_args[@]}" "${template}")"
+
+# Belt-and-suspenders: if any __PLACEHOLDER__ token survived, refuse to emit.
+if echo "${rendered}" | grep -qE '__[A-Z][A-Z_]*__'; then
+  echo "render-alloy-config: ERROR - unfilled placeholders remain:" >&2
+  echo "${rendered}" | grep -oE '__[A-Z][A-Z_]*__' | sort -u | sed 's/^/  /' >&2
+  exit 4
+fi
+
+printf '%s\n' "${rendered}"

--- a/proxy.ts
+++ b/proxy.ts
@@ -32,8 +32,9 @@ function buildCsp(nonce: string): string {
   const connectSrc = [
     "connect-src 'self'",
     "https://in.getclicky.com",
-    "https://lists.louisianamesh.org",
+    "https://lists.gulfcoastmesh.org",
     "https://explorer.gulfcoastmesh.org",
+    "https://meeting.gulfcoastmesh.org",
     "https://raw.githubusercontent.com",
     // Turbopack / webpack HMR websocket in dev.
     ...(isDev ? ["ws://localhost:*", "ws://127.0.0.1:*", "wss://localhost:*"] : []),
@@ -43,7 +44,7 @@ function buildCsp(nonce: string): string {
     "default-src 'self'",
     "base-uri 'self'",
     "object-src 'none'",
-    "form-action 'self' https://lists.louisianamesh.org",
+    "form-action 'self' https://lists.gulfcoastmesh.org",
     "frame-ancestors 'none'",
     ...(isDev ? [] : ["upgrade-insecure-requests"]),
     scriptSrc,


### PR DESCRIPTION
## Summary
- Add /meetings page with calendar and next-meeting card
- Add monitoring collector install docs and scripts
- Update site header, email signup, and proxy config
## Test plan
- [ ] `npm run build` passes
- [ ] `/meetings` renders correctly
- [ ] Dev server still works with updated proxy/CSP