### PR TITLE
Add MeshBuddy/Reserve nav link

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -12,6 +12,7 @@ const nav: readonly NavItem[] = [
   { label: "Maps", href: "/meshmap" },
   { label: "Meetings", href: "/meetings" },
   { label: "Setup", href: "/setup" },
+  { label: "MeshBuddy/Reserve", href: "https://meshbuddy.gulfcoastmesh.org/", external: true },
   { label: "Resources", href: "/links" },
   { label: "Newsletter", href: "/emailsignup" },
   { label: "Docs", href: "/docs" },


### PR DESCRIPTION
## Summary
- Adds **MeshBuddy/Reserve** to the primary nav (after Setup)
- Links externally to https://meshbuddy.gulfcoastmesh.org/ in a new tab
## Test plan
- [ ] Desktop nav shows **MeshBuddy/Reserve** after Setup
- [ ] Mobile menu shows the same item
- [ ] Click opens meshbuddy.gulfcoastmesh.org in a new tab